### PR TITLE
Fixed going left on upgrade screen not working

### DIFF
--- a/ExpandedGalaxy/Systems.cs
+++ b/ExpandedGalaxy/Systems.cs
@@ -531,7 +531,7 @@ namespace ExpandedGalaxy
             static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
             {
                 return HarmonyHelpers.PatchBySequence(instructions, new CodeInstruction[]
-{
+                {
                 new CodeInstruction(OpCodes.Ldarg_0, null),
                 new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "m_CachedUpgradableComponents")),
                 new CodeInstruction(OpCodes.Callvirt, null)

--- a/ExpandedGalaxy/Systems.cs
+++ b/ExpandedGalaxy/Systems.cs
@@ -523,15 +523,25 @@ namespace ExpandedGalaxy
         [HarmonyPatch(typeof(PLShipInfo), "GetUpgradableComponents")]
         internal class MoreUpgrades
         {
-            private static void Postfix(PLShipInfo __instance, ref List<PLShipComponent> ___m_CachedUpgradableComponents, ref List<PLShipComponent> __result)
+            public static void Patch(PLShipInfo instance, List<PLShipComponent> m_CachedUpgradableComponents)
             {
-                PLShipInfoBase plShipInfoBase = (PLShipInfoBase)__instance;
-                if ((UnityEngine.Object)plShipInfoBase == (UnityEngine.Object)null || plShipInfoBase.MyStats == null)
-                    return;
-                ___m_CachedUpgradableComponents.AddRange((IEnumerable<PLShipComponent>)plShipInfoBase.MyStats.GetComponentsOfType(ESlotType.E_COMP_AUTO_TURRET));
-                ___m_CachedUpgradableComponents.AddRange((IEnumerable<PLShipComponent>)plShipInfoBase.MyStats.GetComponentsOfType(ESlotType.E_COMP_HULLPLATING));
-                ___m_CachedUpgradableComponents.RemoveAll((Predicate<PLShipComponent>)(item => item == null));
-                __result = ___m_CachedUpgradableComponents;
+                m_CachedUpgradableComponents.AddRange((IEnumerable<PLShipComponent>)instance.MyStats.GetComponentsOfType(ESlotType.E_COMP_AUTO_TURRET, false));
+                m_CachedUpgradableComponents.AddRange((IEnumerable<PLShipComponent>)instance.MyStats.GetComponentsOfType(ESlotType.E_COMP_HULLPLATING, false));
+            }
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                return HarmonyHelpers.PatchBySequence(instructions, new CodeInstruction[]
+{
+                new CodeInstruction(OpCodes.Ldarg_0, null),
+                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "m_CachedUpgradableComponents")),
+                new CodeInstruction(OpCodes.Callvirt, null)
+                }, new CodeInstruction[]
+                {
+                new CodeInstruction(OpCodes.Ldarg_0, null),
+                new CodeInstruction(OpCodes.Dup, null),
+                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(PLShipInfo), "m_CachedUpgradableComponents")),
+                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MoreUpgrades), "Patch", null, null)),
+                }, HarmonyHelpers.PatchMode.AFTER, HarmonyHelpers.CheckMode.NONNULL, false);
             }
         }
 


### PR DESCRIPTION
Fixed going left on upgrade screen not working by changing postfix on GetUpgradableComponents to a transpiler. the m_CachedUpgradableComponents in the original method was only updated once per second and then for the rest of the time just returned without modification. The original postfix just constantly added duplicates of the hullplating and autoturrets every time leading to the cached components list becoming extremely bloated over time and reseting every second meaning that when you went left from 0 -> max of the list it sent you to index like 60 or 70 and then the on the second that the list reset the length of the list became 17 or so and then the engi UI would send you back to 0 because obviously if your over the max length of the list it should send you back to 0